### PR TITLE
Legacy check prevents the use of a Version module

### DIFF
--- a/lib/globalize/versioning/paper_trail.rb
+++ b/lib/globalize/versioning/paper_trail.rb
@@ -23,7 +23,7 @@ ActiveRecord::Base.class_eval do
 end
 
 # to handle different versions of paper_trail
-version_class = Module.const_defined?(:Version) ? Version : PaperTrail::Version
+version_class = PaperTrail::VERSION.is_a?(String) ? Version : PaperTrail::Version
 
 version_class.class_eval do
 


### PR DESCRIPTION
Hi!

When using the gem in an application that already contains a `Version` module, the `const_defined?` check for older releases of PaperTrail is invalid, because the namespaces collide.

I'm not a big fan of `is_a?` (I'd rather ignore the old version), but this is a simple fix for that.

HTH.
