### PR TITLE
Rails 5 compatibility

### DIFF
--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = 'globalize-versioning'
 
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5'
-  s.add_dependency 'activemodel', '>= 3.2.0', '< 5'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 6'
+  s.add_dependency 'activemodel', '>= 3.2.0', '< 6'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
   s.add_dependency 'paper_trail',  '>= 3.0.0', '< 6'

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 3.2.0', '< 5'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
-  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 5'
+  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 6'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
This is working under Rails 5. Can you please integrate it into the master and remove the Deprecation-Warnings:
"DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from block in <top (required)> at lib/globalize/versioning.rb:26)"