### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ gem install globalize-versioning
 When using bundler, add this line to your `Gemfile`:
 
 ```ruby
-gem 'globalize-versioning', '~> 0.1.0'
+gem 'globalize-versioning'
 ```
 
 ## Usage


### PR DESCRIPTION
Misleading instruction installing old version and making it incompatible with many other gems (such as paper_trail =<4)