### PR TITLE
Update for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ env:
     - RAILS=4.0
     - RAILS=4.1
     - RAILS=4.2
+    - RAILS=5.1
 rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.4.1
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,11 @@ sudo: false
 cache: bundler
 env:
   matrix:
-    - RAILS=3.2
     - RAILS=4.0
     - RAILS=4.1
     - RAILS=4.2
     - RAILS=5.1
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.2.2
   - 2.4.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,5 +20,5 @@ elsif ENV['RAILS'] == '4.2'
 else # Rails 5.1
   # The master of globalize currently supports rails 5
   gem 'globalize', github: 'globalize/globalize'
-  gem 'paper_trail', '7.1.0'
+  gem 'paper_trail', '~> 7.1.3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,11 @@ elsif ENV['RAILS'] == "4.1"
   gem 'activerecord', '~> 4.1.0'
   gem 'activemodel', '~> 4.1.0'
   gem 'globalize', '~> 4.0'
-else # Rails 4.2
+elsif ENV['RAILS'] == "4.2"
   gem 'globalize', '~> 5.0'
   gem 'paper_trail', '4.0.0.beta2'
+else # Rails 5
+  # The master of globalize currently supports rails 5
+  gem 'globalize', github: 'globalize/globalize'
+  gem 'paper_trail', '7.1.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,22 +2,22 @@ source 'https://rubygems.org'
 
 gemspec
 
-if ENV['RAILS'] == "3.2"
+if ENV['RAILS'] == '3.2'
   gem 'activerecord', '~> 3.2.0'
   gem 'activemodel', '~> 3.2.0'
   gem 'globalize', '~> 3.0.4'
-elsif ENV['RAILS'] == "4.0"
+elsif ENV['RAILS'] == '4.0'
   gem 'activerecord', '~> 4.0.0'
   gem 'activemodel', '~> 4.0.0'
   gem 'globalize', '~> 4.0'
-elsif ENV['RAILS'] == "4.1"
+elsif ENV['RAILS'] == '4.1'
   gem 'activerecord', '~> 4.1.0'
   gem 'activemodel', '~> 4.1.0'
   gem 'globalize', '~> 4.0'
-elsif ENV['RAILS'] == "4.2"
+elsif ENV['RAILS'] == '4.2'
   gem 'globalize', '~> 5.0'
   gem 'paper_trail', '4.0.0.beta2'
-else # Rails 5
+else # Rails 5.1
   # The master of globalize currently supports rails 5
   gem 'globalize', github: 'globalize/globalize'
   gem 'paper_trail', '7.1.0'

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 3.2.0', '< 6'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
-  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 7'
+  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 8'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'
   s.add_development_dependency 'minitest'

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activemodel', '>= 3.2.0', '< 6'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
-  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 5'
+  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 7'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'
   s.add_development_dependency 'minitest'

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = 'globalize-versioning'
 
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5'
-  s.add_dependency 'activemodel', '>= 3.2.0', '< 5'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 6'
+  s.add_dependency 'activemodel', '>= 3.2.0', '< 6'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
   s.add_dependency 'paper_trail',  '>= 3.0.0', '< 5'

--- a/lib/globalize/versioning.rb
+++ b/lib/globalize/versioning.rb
@@ -23,5 +23,5 @@ Globalize::ActiveRecord::ActMacro.module_eval do
     end
   end
 
-  alias_method_chain :setup_translates!, :versioning
+  alias_method :setup_translates!, :versioning
 end

--- a/lib/globalize/versioning.rb
+++ b/lib/globalize/versioning.rb
@@ -22,6 +22,8 @@ Globalize::ActiveRecord::ActMacro.module_eval do
       end
     end
   end
-
+  
+  alias_method :versioning, :setup_translates!
   alias_method :setup_translates!, :versioning
+  
 end


### PR DESCRIPTION
I am currently updating my application to Rails 5 and globalize-versioning is currently blocking this because it depends on `activerecord < 5`.

```
Bundler could not find compatible versions for gem "activerecord":
  In Gemfile:
    globalize-versioning was resolved to 0.2.0, which depends on
      globalize (< 6, >= 3.0.4) was resolved to 5.1.0.beta2, which depends on
        activerecord (< 5.2, >= 4.2)

    globalize-versioning was resolved to 0.2.0, which depends on
      activerecord (< 5, >= 3.2.0)

    rails (~> 5.1.3) was resolved to 5.1.3, which depends on
      activerecord (= 5.1.3)
```
