### PR TITLE
Add Rails 5.0 and 5.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ env:
     - RAILS=4.0
     - RAILS=4.1
     - RAILS=4.2
+    - RAILS=5.0
+    - RAILS=5.1
 rvm:
-  - 2.0.0
-  - 2.1
   - 2.2
+  - 2.3.5
+  - 2.4.2

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,17 @@ elsif ENV['RAILS'] == "4.1"
   gem 'activerecord', '~> 4.1.0'
   gem 'activemodel', '~> 4.1.0'
   gem 'globalize', '~> 4.0'
-else # Rails 4.2
+elsif ENV['RAILS'] == "4.2"
+  gem 'activerecord', '~> 4.2.0'
+  gem 'activemodel', '~> 4.2.0'
   gem 'globalize', '~> 5.0'
   gem 'paper_trail', '4.0.0.beta2'
+elsif ENV['RAILS'] == "5.0"
+  gem 'activerecord', '~> 5.0.0'
+  gem 'activemodel', '~> 5.0.0'
+  gem 'globalize', github: 'globalize/globalize'
+  gem 'paper_trail', '~> 7.1.3'
+else # Rails 5.1
+  gem 'globalize', github: 'globalize/globalize'
+  gem 'paper_trail', '~> 7.1.3'
 end

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = 'globalize-versioning'
 
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5'
-  s.add_dependency 'activemodel', '>= 3.2.0', '< 5'
+  s.add_dependency 'activerecord', '>= 3.2.0', '< 6'
+  s.add_dependency 'activemodel', '>= 3.2.0', '< 6'
   s.add_dependency 'globalize', '>= 3.0.4', '< 6'
 
-  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 5'
+  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 8'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'
   s.add_development_dependency 'minitest'

--- a/lib/globalize/versioning.rb
+++ b/lib/globalize/versioning.rb
@@ -2,6 +2,7 @@ require 'globalize'
 
 module Globalize::Versioning
   autoload :PaperTrail, 'globalize/versioning/paper_trail'
+  autoload :InstanceMethods, 'globalize/versioning/instance_methods'
 end
 
 Globalize::ActiveRecord::ActMacro.module_eval do
@@ -9,6 +10,7 @@ Globalize::ActiveRecord::ActMacro.module_eval do
     setup_translates_without_versioning!(options)
 
     if options[:versioning]
+      include Globalize::Versioning::InstanceMethods
 
       # hard-coded for now
       class_attribute :versioning_gem, :instance_accessor => false

--- a/lib/globalize/versioning.rb
+++ b/lib/globalize/versioning.rb
@@ -25,5 +25,6 @@ Globalize::ActiveRecord::ActMacro.module_eval do
     end
   end
 
-  alias_method_chain :setup_translates!, :versioning
+  alias_method :setup_translates_without_versioning!, :setup_translates!
+  alias_method :setup_translates!, :setup_translates_with_versioning!
 end

--- a/lib/globalize/versioning/instance_methods.rb
+++ b/lib/globalize/versioning/instance_methods.rb
@@ -1,0 +1,9 @@
+module Globalize
+  module Versioning
+    module InstanceMethods
+      def rollback
+        translation_caches[::Globalize.locale] = translation.paper_trail.previous_version
+      end
+    end
+  end
+end

--- a/lib/globalize/versioning/paper_trail.rb
+++ b/lib/globalize/versioning/paper_trail.rb
@@ -18,7 +18,9 @@ ActiveRecord::Base.class_eval do
       has_paper_trail_without_globalize(*args)
       include Globalize::Versioning::PaperTrail
     end
-    alias_method_chain :has_paper_trail, :globalize
+
+    alias_method :has_paper_trail_without_globalize, :has_paper_trail
+    alias_method :has_paper_trail, :has_paper_trail_with_globalize
   end
 end
 
@@ -38,5 +40,7 @@ version_class.class_eval do
   def sibling_versions_with_locales
     sibling_versions_without_locales.for_this_locale
   end
-  alias_method_chain :sibling_versions, :locales
+
+  alias_method :sibling_versions_without_locales, :sibling_versions
+  alias_method :sibling_versions, :sibling_versions_with_locales
 end


### PR DESCRIPTION
Inspired by https://github.com/globalize/globalize-versioning/pull/16 this PR adds Rails 5.x support. 

- Remove calls to removed `alias_method_chain`
- Add `rollback` method which was removed from `globalize`