### PR TITLE
Upgrade to Rails 5 and remove older versions of Ruby and Rails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ sudo: false
 cache: bundler
 env:
   matrix:
-    - RAILS=3.2
-    - RAILS=4.0
-    - RAILS=4.1
     - RAILS=4.2
+    - RAILS=5.0
+    - RAILS=5.1
+    - RAILS=5.2
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
-
-if ENV['RAILS'] == "3.2"
-  gem 'activerecord', '~> 3.2.0'
-  gem 'activemodel', '~> 3.2.0'
-  gem 'globalize', '~> 3.0.4'
-elsif ENV['RAILS'] == "4.0"
-  gem 'activerecord', '~> 4.0.0'
-  gem 'activemodel', '~> 4.0.0'
-  gem 'globalize', '~> 4.0'
-elsif ENV['RAILS'] == "4.1"
-  gem 'activerecord', '~> 4.1.0'
-  gem 'activemodel', '~> 4.1.0'
-  gem 'globalize', '~> 4.0'
-else # Rails 4.2
-  gem 'globalize', '~> 5.0'
-  gem 'paper_trail', '4.0.0.beta2'
-end
+gem 'globalize', '~> 5.1'
+gem 'paper_trail', '~> 10.0.1'

--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -16,17 +16,14 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = 'globalize-versioning'
 
-  s.add_dependency 'activerecord', '>= 3.2.0', '< 5'
-  s.add_dependency 'activemodel', '>= 3.2.0', '< 5'
-  s.add_dependency 'globalize', '>= 3.0.4', '< 6'
-
-  s.add_dependency 'paper_trail',  '>= 3.0.0', '< 5'
+  s.add_dependency 'activerecord', '>= 4.2.0', '< 6'
+  s.add_dependency 'activemodel', '>= 4.2.0', '< 6'
+  s.add_dependency 'globalize', '>= 5.1.0', '< 6'
+  s.add_dependency 'paper_trail',  '>= 8', '< 12'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'
   s.add_development_dependency 'minitest'
-
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rdoc'
-
   s.add_development_dependency 'rake'
 end

--- a/lib/globalize/versioning.rb
+++ b/lib/globalize/versioning.rb
@@ -2,6 +2,7 @@ require 'globalize'
 
 module Globalize::Versioning
   autoload :PaperTrail, 'globalize/versioning/paper_trail'
+  autoload :InstanceMethods, 'globalize/versioning/instance_methods'
 end
 
 Globalize::ActiveRecord::ActMacro.module_eval do
@@ -9,6 +10,7 @@ Globalize::ActiveRecord::ActMacro.module_eval do
     setup_translates_without_versioning!(options)
 
     if options[:versioning]
+      include Globalize::Versioning::InstanceMethods
 
       # hard-coded for now
       class_attribute :versioning_gem, :instance_accessor => false
@@ -23,5 +25,6 @@ Globalize::ActiveRecord::ActMacro.module_eval do
     end
   end
 
-  alias_method_chain :setup_translates!, :versioning
+  alias_method :setup_translates_without_versioning!, :setup_translates!
+  alias_method :setup_translates!, :setup_translates_with_versioning!
 end

--- a/lib/globalize/versioning/instance_methods.rb
+++ b/lib/globalize/versioning/instance_methods.rb
@@ -1,0 +1,9 @@
+module Globalize
+  module Versioning
+    module InstanceMethods
+      def rollback
+        translation_caches[::Globalize.locale] = translation.paper_trail.previous_version
+      end
+    end
+  end
+end

--- a/lib/globalize/versioning/paper_trail.rb
+++ b/lib/globalize/versioning/paper_trail.rb
@@ -18,7 +18,8 @@ ActiveRecord::Base.class_eval do
       has_paper_trail_without_globalize(*args)
       include Globalize::Versioning::PaperTrail
     end
-    alias_method_chain :has_paper_trail, :globalize
+    alias_method :has_paper_trail_without_globalize, :has_paper_trail
+    alias_method :has_paper_trail, :has_paper_trail_with_globalize
   end
 end
 
@@ -38,5 +39,6 @@ version_class.class_eval do
   def sibling_versions_with_locales
     sibling_versions_without_locales.for_this_locale
   end
-  alias_method_chain :sibling_versions, :locales
+  alias_method :sibling_versions_without_locales, :sibling_versions
+  alias_method :sibling_versions, :sibling_versions_with_locales
 end

--- a/test/data/models/legacy_post.rb
+++ b/test/data/models/legacy_post.rb
@@ -1,4 +1,5 @@
 class LegacyPost < ActiveRecord::Base
   self.table_name = :posts
+  attribute :title
   translates :title, :versioning => true
 end

--- a/test/data/models/post.rb
+++ b/test/data/models/post.rb
@@ -1,3 +1,4 @@
 class Post < ActiveRecord::Base
+  attribute :title
   translates :title, :versioning => :paper_trail
 end

--- a/test/globalize-versioning/options_test.rb
+++ b/test/globalize-versioning/options_test.rb
@@ -10,6 +10,7 @@ class OptionsTest < MiniTest::Spec
 
     # options passed to paper_trail: :on => :update
     @options_post_class.class_eval do
+      attribute :title
       translates :title, :versioning => { :gem => :paper_trail, :options => { :on => [ :update ] } }
     end
 


### PR DESCRIPTION
This is very similar to #19, and #16. I was a bit more aggressive with not allowing older versions of Ruby and Rails that are no longer supported, in hopes that that will make the Travis tests pass. 

I'd really like to be able to use this in my own projects, so please let me know how I can help get this merged and the version bumped!

Thank you!