### PR TITLE
Update Globalize Dependency

### DIFF
--- a/globalize-versioning.gemspec
+++ b/globalize-versioning.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activerecord', '>= 4.2.0', '< 8.0'
   s.add_dependency 'activemodel', '>= 4.2.0', '< 8.0'
-  s.add_dependency 'globalize', '>= 5.1.0', '< 7'
+  s.add_dependency 'globalize', '>= 5.1.0', '< 8.0'
   s.add_dependency 'paper_trail',  '>= 8', '< 16'
 
   s.add_development_dependency 'database_cleaner', '>= 1.2.0'


### PR DESCRIPTION
This update is required to resolve a dependency conflict between Globalize 7 and Rails 7. 